### PR TITLE
Remove bad Python Syntax

### DIFF
--- a/gitlab/requests/packages/urllib3/connectionpool.py
+++ b/gitlab/requests/packages/urllib3/connectionpool.py
@@ -37,9 +37,6 @@ except ImportError:
 import ssl
 BaseSSLError = ssl.SSLError
 
-except (ImportError, AttributeError): # Platform-specific: No SSL.
-    pass
-
 
 from .request import RequestMethods
 from .response import HTTPResponse


### PR DESCRIPTION
Removed a rogue except statement causing the plugin not to run.
