### PR TITLE
Config option to enable/disable SSL certificate verification

### DIFF
--- a/GitlabIntegrate.sublime-settings
+++ b/GitlabIntegrate.sublime-settings
@@ -33,5 +33,8 @@
 	"project_id": 0,
 
 	//Your user token for GitLab, found in [host]/profile/account 
-	"user_token":"token not set"	
+	"user_token":"token not set",
+	
+	//set to false if you want to use HTTPS with a self-signed certificate
+	"verify_ssl":true
 }

--- a/gitlab_integrate.py
+++ b/gitlab_integrate.py
@@ -56,7 +56,8 @@ class Settings:
 	"HOST": "project_host",
 	"OUTPUT_PREFIX": "output_prefix",
 	"PROJECT": "project_id",
-	"TOKEN": "user_token"	
+	"TOKEN": "user_token",
+	"SSL": "verify_ssl"
 	}
 
 	#Settings default/unset values
@@ -95,6 +96,7 @@ class Settings:
 		self.project_host = self._load_setting("HOST", self.NO_HOST)
 		self.project_id = self._load_setting("PROJECT", 0)
 		self.user_token = self._load_setting("TOKEN", self.NO_TOKEN)
+		self.verify_ssl = self._load_setting("SSL", False)
 		
 		OUTPUT_PREFIX = self._load_setting("OUTPUT_PREFIX", "[GLI]:")
 		EDIT_ISSUE_VIEW_NAME = self._load_setting("EDIT_ISSUE_VIEW_NAME", "[GLI]: Editing Issue")
@@ -113,7 +115,7 @@ class Settings:
 			return
 		elif host != self.project_host or token != self.user_token:
 			global git
-			git = gitlab.Gitlab(self.project_host, token=self.user_token)
+			git = gitlab.Gitlab(self.project_host, token=self.user_token, verify_ssl=self.verify_ssl)
 			_status_print("Reconnected to Gitlab using host " + self.project_host + " and token " + self.user_token)
 
 	def change_setting(self, setting, value):


### PR DESCRIPTION
Hi there. I've added a config option to enable/disable SSL certificate verification. This is needed if one hosts the gitlab instance on HTTPS, but with a self-signed certificate.

Hope you'll include it, since this way is way easier than patching each of my instances of GitlabIntegrate between different computers and OSes.
